### PR TITLE
Fix characters rendering incorrectly on linux by pinvoking setlocale

### DIFF
--- a/src/Blackguard/Program.cs
+++ b/src/Blackguard/Program.cs
@@ -21,6 +21,7 @@ public static class Program {
 
     static Program() {
         Platform = Platform.GetPlatform();
+        Platform.Configure();
     }
 
     public static void Main(string[] args) {

--- a/src/Blackguard/Utilities/Platform.cs
+++ b/src/Blackguard/Utilities/Platform.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Runtime.InteropServices;
 
 namespace Blackguard.Utilities;
 
@@ -26,11 +27,18 @@ public abstract class Platform {
 
     public abstract string DataPath();
 
+    public abstract void Configure();
+
     public abstract List<string> ExtractNativeDependencies();
 
     public class Linux : Platform {
+        [DllImport("libc", SetLastError = true, CharSet = CharSet.Unicode)]
+        private static extern void setlocale(int category, string locale);
+
+        private const int LC_ALL = 6;
+
         public override string CachePath() {
-            var xdg = Environment.GetEnvironmentVariable("XDG_CACHE_HOME");
+            string? xdg = Environment.GetEnvironmentVariable("XDG_CACHE_HOME");
 
             if (!string.IsNullOrEmpty(xdg))
                 return Path.Combine(xdg, "blackguard");
@@ -38,8 +46,12 @@ public abstract class Platform {
                 return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), ".cache", "blackguard");
         }
 
+        public override void Configure() {
+            setlocale(LC_ALL, "");
+        }
+
         public override string DataPath() {
-            var xdg = Environment.GetEnvironmentVariable("XDG_DATA_HOME");
+            string? xdg = Environment.GetEnvironmentVariable("XDG_DATA_HOME");
 
             if (!string.IsNullOrEmpty(xdg))
                 return Path.Combine(xdg, "blackguard");
@@ -55,6 +67,10 @@ public abstract class Platform {
     public class Windows : Platform {
         public override string CachePath() {
             return Path.Combine(DataPath(), "cache");
+        }
+
+        public override void Configure() {
+            return; // Nothing specific to configure on windows yet.
         }
 
         public override string DataPath() {

--- a/src/Blackguard/Utilities/Utils.cs
+++ b/src/Blackguard/Utilities/Utils.cs
@@ -6,12 +6,14 @@ public static class CursesUtils {
     public static void WindowAddLinesWithHighlight(nint window, params (Highlight highlight, int x, int y, string text)[] segments) {
         foreach ((Highlight highlight, int x, int y, string text) in segments) {
             NCurses.MoveWindowAddString(window, y, x, text);
-            Mvwchgat(window, x, y, text.Length, highlight.GetAttr(), (short)highlight.GetPair());
+            mvwchgat(window, x, y, text.Length, highlight.GetAttr(), (short)highlight.GetPair());
         }
     }
 
-    public static void Mvwchgat(nint window, int x, int y, int len, uint attr, short pair) {
+#pragma warning disable IDE1006 // Shut up naming violation
+    public static void mvwchgat(nint window, int x, int y, int len, uint attr, short pair) {
         NCurses.WindowMove(window, y, x);
-        NCurses.WindowChangeAttribute(window,  len, attr, pair, nint.Zero);
+        NCurses.WindowChangeAttribute(window, len, attr, pair, nint.Zero);
     }
 }
+#pragma warning restore IDE1006


### PR DESCRIPTION
Fixes rendering by calling the libc setlocale function on linux and changing LC_ALL to "".

Addresses task #46 and story #6.