### PR TITLE
Improve selection of UI elements and fix escape sequences being handled incorrectly

### DIFF
--- a/Blackguard.sln
+++ b/Blackguard.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.002.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Blackguard", ".\Blackguard\Blackguard.csproj", "{5ED6B993-9BD7-450D-A2EF-04D7AA01ADA7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Blackguard", ".\src\Blackguard\Blackguard.csproj", "{5ED6B993-9BD7-450D-A2EF-04D7AA01ADA7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Blackguard.Tests", "Blackguard.Tests\Blackguard.Tests.csproj", "{40A1DC96-F6EE-404B-AB2B-8E4DDC6E769E}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Blackguard.Tests", ".\src\Blackguard.Tests\Blackguard.Tests.csproj", "{40A1DC96-F6EE-404B-AB2B-8E4DDC6E769E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Blackguard/Game.cs
+++ b/src/Blackguard/Game.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using Blackguard.UI.Scenes;
 using Mindmagma.Curses;
 
@@ -27,29 +28,13 @@ public class Game {
         scene = new MainMenuScene();
     }
 
-    private static readonly List<int> input = new();
-
-    private static void PollInput() {
-        input.Clear();
-        int c;
-        try {
-            while ((c = NCurses.WindowGetChar(scene.CurrentWin.handle)) != -1)
-                input.Add(c);
-        }
-        catch { } // Empty catch block because WindowGetChar throws if there is not a currently pressed key
-    }
-
-    public static bool IsInput() => input?.Count > 0;
-
-    public static bool KeyPressed(int keyCode) => input?.Contains(keyCode) ?? false;
-
     public void Run() {
         bool shouldExit = false;
 
         while (!shouldExit) {
             gameTimer = Stopwatch.StartNew();
 
-            PollInput();
+            InputHandler.PollInput(scene.CurrentWin.handle);
 
             shouldExit = !scene.RunTick();
             scene.Render();

--- a/src/Blackguard/KeyDefs.cs
+++ b/src/Blackguard/KeyDefs.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using Mindmagma.Curses;
+
+namespace Blackguard;
+
+public static class InputHandler {
+    private static readonly List<int> received_codes = new(); // Raw bytes from ncurses
+    public static readonly List<int> pressed_keys = new(); // Processed input for special keys and escape sequences
+
+    private static readonly Dictionary<(int, int, int), int> SpecialKeyDefs = new() {
+        { ( 27, 79, 65 ), CursesKey.UP },
+        { ( 27, 79, 66 ), CursesKey.DOWN },
+        { ( 27, 79, 67 ), CursesKey.RIGHT },
+        { ( 27, 79, 68 ), CursesKey.LEFT },
+    };
+
+    public static void PollInput(nint windowHandle) {
+        received_codes.Clear();
+        pressed_keys.Clear();
+
+        int c;
+        try {
+            while ((c = NCurses.WindowGetChar(windowHandle)) != -1)
+                received_codes.Add(c);
+        }
+        catch { } // Empty catch block because WindowGetChar throws if there is not a currently pressed key
+
+        // Check if any triplets match the special key defs
+        for (int i = 0; i < received_codes.Count; i++) {
+            if (received_codes.Count - i > 2 && SpecialKeyDefs.TryGetValue((received_codes[i], received_codes[i + 1], received_codes[i + 2]), out int key)) {
+                pressed_keys.Add(key);
+                i += 3;
+            }
+            else
+                pressed_keys.Add(received_codes[i]);
+        }
+    }
+
+    public static bool HasInputThisTick() => pressed_keys?.Count > 0;
+
+    public static bool KeyPressed(int keyCode) => pressed_keys?.Contains(keyCode) ?? false;
+
+
+}

--- a/src/Blackguard/Program.cs
+++ b/src/Blackguard/Program.cs
@@ -37,8 +37,9 @@ public static class Program {
             Environment.Exit(1);
         }
 
-        NCurses.SetCursor(0); // Hide the color
-        NCurses.NoEcho();
+        NCurses.SetCursor(0); // Hide the cursor
+        NCurses.CBreak(); // Makes input immediately available to the terminal instead of performing line buffering
+        NCurses.NoEcho(); // Stops input from being printed to the screen automatically
         NCurses.StartColor(); // Starts the color functionality
         ColorHandler.Init(); // Initialize all of our color pairs and highlights
 

--- a/src/Blackguard/UI/ISelectable.cs
+++ b/src/Blackguard/UI/ISelectable.cs
@@ -1,0 +1,9 @@
+﻿namespace Blackguard.UI;
+
+public interface ISelectable {
+    public bool Selected { get; protected set; }
+
+    public void Select();
+
+    public void Deselect();
+}

--- a/src/Blackguard/UI/Scenes/MainMenuScene.cs
+++ b/src/Blackguard/UI/Scenes/MainMenuScene.cs
@@ -1,5 +1,4 @@
-﻿using Blackguard.Utilities;
-using Mindmagma.Curses;
+﻿using Mindmagma.Curses;
 
 namespace Blackguard.UI.Scenes;
 
@@ -50,18 +49,19 @@ public class MainMenuScene : Scene {
         UIButton creditsButton = new(Credits, () => { });
         UIButton quitButton = new(Quit, () => { });
 
-        container = new UIContainer(Alignment.Center, logoText, startButton, settingsButton, creditsButton, quitButton);
+        container = new UIContainer(Alignment.Center, logoText, startButton, settingsButton, creditsButton, quitButton) { Selected = true };
     }
 
     int tick = 0;
     public override bool RunTick() {
+        ProcessInput();
+
         tick++;
         return true;
     }
 
     public override void Render() {
-        /* if (tick % 60 == 0) */
-        /*     NCurses.MoveWindowAddString(CurrentWin.handle, 0, 0, $"ticks {tick}, seconds {tick / 60}"); */
+        NCurses.MoveWindowAddString(CurrentWin.handle, 0, 0, $"ticks {tick}, seconds {tick / 60}");
 
         container.Render(CurrentWin.handle, 0, 0, CurrentWin.w, CurrentWin.h);
     }

--- a/src/Blackguard/UI/Scenes/Scene.cs
+++ b/src/Blackguard/UI/Scenes/Scene.cs
@@ -24,30 +24,28 @@ public abstract class Scene : ISizeProvider {
     public abstract void Finish();
 
     // Default impl handles navigating various UI Elements. For the game's main view it should not need to use this.
-    private const int DEBOUNCETICKS = 20;
+    private const int DEBOUNCETICKS = 30;
     private int debounceTimer = DEBOUNCETICKS + 1; // Just needs a default value above DEBOUNCETICKS
     private int lastKey;
 
     public virtual void ProcessInput() {
         container.ProcessInput();
 
-        if (Game.KeyPressed(CursesKey.DOWN) && debounceTimer > DEBOUNCETICKS) {
-            container.Next();
+        if (InputHandler.KeyPressed(CursesKey.DOWN) && debounceTimer > DEBOUNCETICKS) {
+            container.Next(true);
             lastKey = CursesKey.DOWN;
             debounceTimer = 0;
         }
-        else if (!Game.KeyPressed(CursesKey.DOWN) && lastKey == CursesKey.DOWN) {
+        else if (!InputHandler.KeyPressed(CursesKey.DOWN) && lastKey == CursesKey.DOWN)
             debounceTimer = DEBOUNCETICKS + 1; // Set it to something above DEBOUNCETICKS so that the key can be pressed again if someone is rapidly pressing
-        }
 
-        if (Game.KeyPressed(CursesKey.UP) && debounceTimer > DEBOUNCETICKS) {
-            container.Prev();
+        if (InputHandler.KeyPressed(CursesKey.UP) && debounceTimer > DEBOUNCETICKS) {
+            container.Prev(true);
             lastKey = CursesKey.UP;
             debounceTimer = DEBOUNCETICKS + 1;
         }
-        else if (!Game.KeyPressed(CursesKey.UP) && lastKey == CursesKey.UP) {
+        else if (!InputHandler.KeyPressed(CursesKey.UP) && lastKey == CursesKey.UP)
             debounceTimer = 100;
-        }
 
         // Can add left and right eventually if planning to support more than just vertical menus
 

--- a/src/Blackguard/UI/UIButton.cs
+++ b/src/Blackguard/UI/UIButton.cs
@@ -5,9 +5,11 @@ using Mindmagma.Curses;
 
 namespace Blackguard.UI;
 
-public class UIButton : UIElement {
+public class UIButton : UIElement, ISelectable {
     private string[] _label;
     private readonly Action _onPress;
+
+    public bool Selected { get; set; }
 
     public UIButton(string[] label, Action onPress) {
         _label = label;
@@ -19,7 +21,7 @@ public class UIButton : UIElement {
     }
 
     public override void ProcessInput() {
-        if (Game.KeyPressed(CursesKey.ENTER)) {
+        if (InputHandler.KeyPressed(CursesKey.ENTER)) {
             _onPress();
         }
     }
@@ -29,6 +31,14 @@ public class UIButton : UIElement {
     }
 
     public override void Render(nint window, int x, int y, int maxy, int maxh) {
-        CursesUtils.WindowAddLinesWithHighlight(window, _label.Select((line, i) => (i == _label.Length - 1 ? Highlight.TextSel : Highlight.Text, x, y + i, _label[i])).ToArray());
+        CursesUtils.WindowAddLinesWithHighlight(window, _label.Select((line, i) => (i == _label.Length - 1 && Selected ? Highlight.TextSel : Highlight.Text, x, y + i, _label[i])).ToArray());
+    }
+
+    public void Select() {
+        Selected = true;
+    }
+
+    public void Deselect() {
+        Selected = false;
     }
 }

--- a/src/Blackguard/UI/UIElement.cs
+++ b/src/Blackguard/UI/UIElement.cs
@@ -1,16 +1,7 @@
 ﻿namespace Blackguard.UI;
 
 public abstract class UIElement : ISizeProvider {
-    protected bool _selected;
     protected Alignment _alignment;
-
-    public void Select() {
-        _selected = true;
-    }
-
-    public void Deselect() {
-        _selected = false;
-    }
 
     public void ChangeAlignment(Alignment alignment, bool replace = false) {
         if (replace)

--- a/src/Blackguard/Utilities/ColorHandler.cs
+++ b/src/Blackguard/Utilities/ColorHandler.cs
@@ -10,6 +10,7 @@ public enum Color : short {
 
 public enum ColorPair {
     Text = 1,
+    TextSel,
 }
 
 public enum Highlight {
@@ -25,12 +26,13 @@ public static class ColorHandler {
     ];
 
     public static readonly Color[][] ColorPairDefs = [
-        [ Color.TextFg, Color.TextBg ] // It would be nice if it didn't need to specify the Color enum
+        [ Color.TextFg, Color.TextBg ], // It would be nice if it didn't need to specify the Color enum
+        [ Color.TextBg, Color.TextFg ]
     ];
 
     public static readonly Dictionary<Highlight, (ColorPair pair, uint attr)> HighlightDefs = new() {
         { Highlight.Text, (ColorPair.Text, 0) },
-        { Highlight.TextSel, (ColorPair.Text, CursesAttribute.UNDERLINE) }
+        { Highlight.TextSel, (ColorPair.TextSel, CursesAttribute.UNDERLINE) }
     };
 
     public static ColorPair GetPair(this Highlight highlight) => HighlightDefs[highlight].pair;


### PR DESCRIPTION
UI Containers have been reworked to handle selecting child elements differently (and hopefully without any index out-of-bounds errors)

The keys returned from wgetch are processed for escape sequences so buttons like arrow keys are detected. I am not sure how consistent escape sequences are between terminals, so this may lead to issues on other terminal emulators later down the line.

Addresses task #52 and story #6 