### PR TITLE
Add info popup, system for handling popup input properly

### DIFF
--- a/src/Blackguard/UI/Drawable.cs
+++ b/src/Blackguard/UI/Drawable.cs
@@ -68,5 +68,9 @@ public abstract class Drawable : IDisposable, ISizeProvider, IOffsetProvider {
 
     public abstract void Move(int newx, int newy);
 
+    public void ReapplyHighlight() {
+        ChangeHighlight(Highlight);
+    }
+
     public abstract void Resize(int neww, int newh);
 }

--- a/src/Blackguard/UI/Popups/InfoPopup.cs
+++ b/src/Blackguard/UI/Popups/InfoPopup.cs
@@ -1,0 +1,56 @@
+using System.Linq;
+using Blackguard.UI.Elements;
+using Blackguard.Utilities;
+using Mindmagma.Curses;
+
+namespace Blackguard.UI.Popups;
+
+public enum InfoType {
+    Info,
+    Warning,
+    Error
+}
+
+public class InfoPopup : Popup {
+    private readonly UIContainer container;
+    private readonly Highlight highlight;
+
+    public InfoPopup(string name, InfoType type, string[] contents) : base(name, Highlight.Text, contents.Max(s => s.Length) + 2, contents.Length + 4) {
+        highlight = type switch {
+            InfoType.Info => Highlight.Text,
+            InfoType.Warning => Highlight.TextWarning,
+            InfoType.Error => Highlight.TextError,
+            _ => Highlight.Text,
+        };
+
+        container = new(Alignment.Center) {
+            Border = true,
+            BorderSel = highlight,
+            BorderUnsel = highlight,
+        };
+
+        container.Add(new UIText(contents) { Highlight = highlight });
+        container.Add(new UISpace(0, 1));
+        container.Add(new UIButton(["Ok"], (s) => { s.ClosePopup(this); }));
+
+        container.Select();
+        container.SelectFirstSelectable();
+    }
+
+    public override void Render(Game state) {
+        container.Render(Panel, 0, 0, Panel.w, Panel.h);
+    }
+
+    public override bool RunTick(Game state) {
+        if (state.Input.KeyPressed(CursesKey.DOWN))
+            container.Next(true);
+
+        if (state.Input.KeyPressed(CursesKey.UP))
+            container.Prev(true);
+
+        if (Focused)
+            container.ProcessInput(state);
+
+        return true;
+    }
+}

--- a/src/Blackguard/UI/Popups/Popup.cs
+++ b/src/Blackguard/UI/Popups/Popup.cs
@@ -1,12 +1,20 @@
 using Blackguard.Utilities;
+using Mindmagma.Curses;
 
 namespace Blackguard.UI.Popups;
 
 public abstract class Popup : ISizeProvider, IOffsetProvider {
     public Panel Panel { get; protected set; }
 
+    public bool Focused;
+    public bool Closed = false;
+
     public Popup(string name, Highlight background, int x, int y, int w, int h) {
         Panel = new Panel(name, background, x, y, w, h);
+    }
+
+    public Popup(string name, Highlight background, int w, int h) {
+        Panel = new Panel(name, background, (NCurses.Columns - w) / 2, (NCurses.Lines - h) / 2, w, h);
     }
 
     public abstract bool RunTick(Game state);

--- a/src/Blackguard/UI/Scenes/PlayerCreationScene.cs
+++ b/src/Blackguard/UI/Scenes/PlayerCreationScene.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using Blackguard.UI.Elements;
+using Blackguard.UI.Popups;
 using Blackguard.Utilities;
 
 namespace Blackguard.UI.Scenes;
@@ -49,13 +50,13 @@ public class PlayerCreationScene : Scene {
         UIButton finish = new("Create Player".ToLargeText(), (state) => {
             string storedText = _nameInput.GetStoredText();
 
-            if (storedText.Length < 0) {
-                // TODO: Create some error popup system
+            if (storedText.Length == 0) {
+                state.OpenPopup(new InfoPopup("NameTooShortWarning", InfoType.Warning, ["A name must be choosen to continue!"]), true);
                 return;
             }
 
             if (File.Exists(Path.Combine(Game.PlayerPath, storedText + ".plr"))) {
-                // TODO: Create some error popup system
+                state.OpenPopup(new InfoPopup("PlayerExistsWarning", InfoType.Warning, [$"A player with the name {storedText} already exists!"]), true);
                 return;
             }
 

--- a/src/Blackguard/UI/Scenes/Scene.cs
+++ b/src/Blackguard/UI/Scenes/Scene.cs
@@ -5,6 +5,8 @@ using Mindmagma.Curses;
 namespace Blackguard.UI.Scenes;
 
 public abstract class Scene {
+    public bool Focused = true;
+
     // Should be defined in the constructor inheriting Scene. Default container for the Scene where elements should be stored
     protected UIContainer container = null!;
 
@@ -20,7 +22,8 @@ public abstract class Scene {
 
     // Default impl handles navigating various UI Elements. For the game's main view it should not need to use this.
     public virtual void ProcessInput(Game state) {
-        container.ProcessInput(state);
+        if (!Focused)
+            return;
 
         // TODO: Terminal does not report keys every tick properly, so we may have to reduce the tick rate or figure out some other way to detect keys being held
         if (state.Input.KeyPressed(CursesKey.DOWN))
@@ -28,5 +31,7 @@ public abstract class Scene {
 
         if (state.Input.KeyPressed(CursesKey.UP))
             container.Prev(true);
+
+        container.ProcessInput(state);
     }
 }

--- a/src/Blackguard/UI/Scenes/WorldCreationScene.cs
+++ b/src/Blackguard/UI/Scenes/WorldCreationScene.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using Blackguard.UI.Elements;
+using Blackguard.UI.Popups;
 using Blackguard.Utilities;
 
 namespace Blackguard.UI.Scenes;
@@ -19,13 +20,13 @@ public class WorldCreationScene : Scene {
         UIButton finish = new("Create World".ToLargeText(), (state) => {
             string storedText = _nameInput.GetStoredText();
 
-            if (storedText.Length < 0) {
-                // TODO: Create some error popup system
+            if (storedText.Length == 0) {
+                state.OpenPopup(new InfoPopup("NameTooShortWarning", InfoType.Warning, ["A name must be choosen to continue!"]), true);
                 return;
             }
 
             if (File.Exists(Path.Combine(Game.WorldPath, storedText + ".wld"))) {
-                // TODO: Create some error popup system
+                state.OpenPopup(new InfoPopup("WorldExistsWarning", InfoType.Warning, [$"A world with the name {storedText} already exists!"]), true);
                 return;
             }
 

--- a/src/Blackguard/Utilities/ColorHandler.cs
+++ b/src/Blackguard/Utilities/ColorHandler.cs
@@ -6,91 +6,154 @@ namespace Blackguard.Utilities;
 public enum Color : short {
     TextFg = 8,
     TextBg,
+    TextBright,
+    TextQuiet,
+    TextQuieter,
+    TextQuietest,
+
+    White,
+    Gray90,
+    Gray80,
+    Gray70,
+    Gray60,
+    Gray50,
+    Gray40,
+    Gray30,
+    Gray20,
+    Gray10,
+    Black,
+
+    Red,
+    RedOrange,
+    Orange,
+    Yellow,
+    Yuck,
+    Green,
+    Teal,
+    Blue,
+    DeepBlue,
+    Purple,
+    Magenta,
+    Pink,
+
+    LightRed,
+    LightRedOrange,
+    LightOrange,
+    LightYellow,
+    LightYuck,
+    LightGreen,
+    LightTeal,
+    LightBlue,
+    LightDeepBlue,
+    LightPurple,
+    LightMagenta,
+    LightPink,
+
+    DarkRed,
+    DarkRorange,
+    DarkOrange,
+    DarkYellow,
+    DarkYuck,
+    DarkGreen,
+    DarkTeal,
+    DarkBlue,
+    DarkDeepBlue,
+    DarkPurple,
+    DarkMagenta,
+    DarkPink,
 }
 
 public enum ColorPair : uint {
     Text = 1,
     TextSel,
+    Warning,
+    Error,
 }
 
 public enum Highlight {
     Text,
     TextSel,
     TextSelUnderline,
+    TextWarning,
+    TextError,
 }
 
 public static class ColorHandler {
     // Color definitions, aligned with the Colors enum, so the 0th element is the RGB set for Text
     public static readonly short[][] ColorDefs = [
-        [ 209, 215, 227 ],  // textNormal
-        [  38,  40,  48 ],  // backgroundMenu
+        [ 209, 215, 227 ],  // TextNormal
+        [ 38,  40,  48  ],  // BackgroundMenu
 
-        [ 242, 247, 255 ],  // textBright
-        [ 149, 154, 164 ],  // textQuiet
-        [ 106, 110, 119 ],  // textQuieter
-        [  63,  66,  74 ],  // textQuietest
+        [ 242, 247, 255 ],  // TextBright
+        [ 149, 154, 164 ],  // TextQuiet
+        [ 106, 110, 119 ],  // TextQuieter
+        [ 63,  66,  74  ],  // TextQuietest
 
-        [ 255, 255, 255 ],  // white
-        [ 230, 230, 230 ],  // gray90
-        [ 204, 204, 204 ],  // gray80
-        [ 179, 179, 179 ],  // gray70
-        [ 153, 153, 153 ],  // gray60
-        [ 128, 128, 128 ],  // gray50
-        [ 102, 102, 102 ],  // gray40
-        [  77,  77,  77 ],  // gray30
-        [  51,  51,  51 ],  // gray20
-        [  26,  26,  26 ],  // gray10
-        [   0,   0,   0 ],  // black
+        [ 255, 255, 255 ],  // White
+        [ 230, 230, 230 ],  // Gray90
+        [ 204, 204, 204 ],  // Gray80
+        [ 179, 179, 179 ],  // Gray70
+        [ 153, 153, 153 ],  // Gray60
+        [ 128, 128, 128 ],  // Gray50
+        [ 102, 102, 102 ],  // Gray40
+        [ 77,  77,  77  ],  // Gray30
+        [ 51,  51,  51  ],  // Gray20
+        [ 26,  26,  26  ],  // Gray10
+        [ 0,   0,   0   ],  // Black
 
-        [ 242, 85,   85 ],  // red
-        [ 242, 119,  85 ],  // rorange
-        [ 242, 143,  85 ],  // orange
-        [ 242, 205,  85 ],  // yellow
-        [ 190, 242,  85 ],  // yuck
-        [ 127, 242,  85 ],  // green
-        [  85, 242, 199 ],  // teal
-        [  85, 192, 242 ],  // blue
-        [  85, 109, 242 ],  // deepBlue
-        [ 167,  85, 242 ],  // purple
-        [ 234,  85, 242 ],  // magenta
-        [ 242,  85, 163 ],  // pink
+        [ 242, 85,  85  ],  // Red
+        [ 242, 119, 85  ],  // RedOrange
+        [ 242, 143, 85  ],  // Orange
+        [ 242, 205, 85  ],  // Yellow
+        [ 190, 242, 85  ],  // Yuck
+        [ 127, 242, 85  ],  // Green
+        [ 85,  242, 199 ],  // Teal
+        [ 85,  192, 242 ],  // Blue
+        [ 85,  109, 242 ],  // DeepBlue
+        [ 167, 85,  242 ],  // Purple
+        [ 234, 85,  242 ],  // Magenta
+        [ 242, 85,  163 ],  // Pink
 
-        [ 255, 153, 153 ],  // lightRed
-        [ 255, 175, 153 ],  // lightRorange
-        [ 255, 191, 153 ],  // lightOrange
-        [ 255, 231, 153 ],  // lightYellow
-        [ 221, 255, 153 ],  // lightYuck
-        [ 180, 255, 153 ],  // lightGreen
-        [ 153, 255, 227 ],  // lightTeal
-        [ 153, 222, 255 ],  // lightBlue
-        [ 153, 168, 255 ],  // lightDeepBlue
-        [ 206, 153, 255 ],  // lightPurple
-        [ 250, 153, 255 ],  // lightMagenta
-        [ 255, 153, 203 ],  // lightPink
+        [ 255, 153, 153 ],  // LightRed
+        [ 255, 175, 153 ],  // LightRedOrange
+        [ 255, 191, 153 ],  // LightOrange
+        [ 255, 231, 153 ],  // LightYellow
+        [ 221, 255, 153 ],  // LightYuck
+        [ 180, 255, 153 ],  // LightGreen
+        [ 153, 255, 227 ],  // LightTeal
+        [ 153, 222, 255 ],  // LightBlue
+        [ 153, 168, 255 ],  // LightDeepBlue
+        [ 206, 153, 255 ],  // LightPurple
+        [ 250, 153, 255 ],  // LightMagenta
+        [ 255, 153, 203 ],  // LightPink
 
-        [ 153,  31,  31 ],  // darkRed
-        [ 153,  57,  31 ],  // darkRorange
-        [ 153,  76,  31 ],  // darkOrange
-        [ 153, 124,  31 ],  // darkYellow
-        [ 113, 153,  31 ],  // darkYuck
-        [  63, 153,  31 ],  // darkGreen
-        [  31, 153, 120 ],  // darkTeal
-        [  31, 114, 153 ],  // darkBlue
-        [  31,  49, 153 ],  // darkDeepBlue
-        [  95,  31, 153 ],  // darkPurple
-        [ 147,  31, 153 ],  // darkMagenta
-        [ 153,  31,  91 ],  // darkPink
+        [ 153, 31,  31  ],  // DarkRed
+        [ 153, 57,  31  ],  // DarkRorange
+        [ 153, 76,  31  ],  // DarkOrange
+        [ 153, 124, 31  ],  // DarkYellow
+        [ 113, 153, 31  ],  // DarkYuck
+        [ 63,  153, 31  ],  // DarkGreen
+        [ 31,  153, 120 ],  // DarkTeal
+        [ 31,  114, 153 ],  // DarkBlue
+        [ 31,  49,  153 ],  // DarkDeepBlue
+        [ 95,  31,  153 ],  // DarkPurple
+        [ 147, 31,  153 ],  // DarkMagenta
+        [ 153, 31,  91  ],  // DarkPink
     ];
 
     public static readonly Color[][] ColorPairDefs = [
-        [ Color.TextFg, Color.TextBg ], // It would be nice if it didn't need to specify the Color enum
-        [ Color.TextBg, Color.TextFg ]
+        [ Color.TextFg, Color.TextBg ], // Text
+        [ Color.TextBg, Color.TextFg ], // TextSel
+        [ Color.Yellow, Color.TextBg ], // Error
+        [ Color.Red,    Color.TextBg ]  // Warning
     ];
 
     public static readonly Dictionary<Highlight, (ColorPair pair, uint attr)> HighlightDefs = new() {
         { Highlight.Text,             (ColorPair.Text,    0) },
         { Highlight.TextSel,          (ColorPair.TextSel, 0) },
         { Highlight.TextSelUnderline, (ColorPair.TextSel, CursesAttribute.UNDERLINE) },
+        { Highlight.TextWarning,      (ColorPair.Warning, 0)},
+        { Highlight.TextError,        (ColorPair.Error,   0)}
     };
 
     // Gets the pair number

--- a/src/Blackguard/Utilities/Utils.cs
+++ b/src/Blackguard/Utilities/Utils.cs
@@ -89,4 +89,11 @@ public static class Utils {
             ret[3].ToString()
         ];
     }
+
+    public static string[] Wrap(this string str, int lines) {
+        throw new NotImplementedException();
+        /* string[] ret = new string[lines]; */
+
+        /* string[] split = str.Split(' '); */
+    }
 }


### PR DESCRIPTION
Adds an InfoPopup class, and modified scene/popup rendering and ticking to support restricting input to a specific popup. This isn't handled super well, and requires that everything processing input (scenes, popups) checks if it's focused before running any input handling. Oh well.

Addresses task #91 story #6 

Partially fixes #90, but the very first popup window to be opened still resets the main window, while all subsequent openings and closings seem fine.